### PR TITLE
Add Google Analytics gtag script

### DIFF
--- a/my-app/index.html
+++ b/my-app/index.html
@@ -62,6 +62,16 @@
     <link rel="canonical" href="https://www.ascendons.in/" />
 
     <!-- <script src="https://cdn.jsdelivr.net/npm/jparticles@latest/dist/jparticles.min.js"></script> -->
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8FHZGCZ236"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8FHZGCZ236');
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Adds the Google Analytics (gtag.js) tracking snippet (G-8FHZGCZ236) to the app's `<head>`

## Test plan
- [ ] Verify the site loads without errors
- [ ] Confirm gtag events show up in Google Analytics real-time view