### PR TITLE
Fix CI build failure: bump Node to 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         working-directory: my-app

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         working-directory: my-app


### PR DESCRIPTION
## Summary
- The GitHub Actions workflows (`deploy.yml`, `main.yml`) pinned `node-version: '18'`, which bundles an npm version affected by npm/cli#4828.
- That bug can cause npm to skip installing the correct platform-specific `@tailwindcss/oxide` optional dependency, producing `Error: Cannot find native binding` during `vite build`.
- Bumping to Node 20 (with a fixed npm) resolves it.

## Test plan
- [ ] Confirm the "Lint Check" and "Deploy to GitHub Pages" workflows run successfully after merge